### PR TITLE
Change placeholder in bcf_filter

### DIFF
--- a/tools/bcf_filter.cwl
+++ b/tools/bcf_filter.cwl
@@ -16,9 +16,9 @@ arguments:
     shellQuote: false
     valueFrom: >-
       $(inputs.chr_list.path) |
-      xargs -ICH -P 4
+      xargs -Ichr_placeholder_108 -P 4
       sh -c
-      'bcftools mpileup --output /dev/stdout --fasta-ref $(inputs.reference_fasta.path) -r CH -T $(inputs.snp_bed.path) $(inputs.input_align.path) > $(inputs.input_align.nameroot).CH.pileup.vcf' &&
+      'bcftools mpileup --output /dev/stdout --fasta-ref $(inputs.reference_fasta.path) -r chr_placeholder_108 -T $(inputs.snp_bed.path) $(inputs.input_align.path) > $(inputs.input_align.nameroot).chr_placeholder_108.pileup.vcf' &&
       find . -not -empty -name '*.pileup.vcf' > pileup_list.txt &&
       vcf-concat -f pileup_list.txt > $(inputs.input_align.nameroot).merged.vcf &&
       bcftools call -c $(inputs.input_align.nameroot).merged.vcf > $(inputs.input_align.nameroot).bcf.called.vcf


### PR DESCRIPTION
<!--Pull Request Template-->

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

This PR changes the placeholder for the bcf command in the bcf_filter tool to one less likely to be used in an input file.

Example Cavatica run affected by the error where the sample id contains "CH" and is getting changed to "chr_10": https://cavatica.sbgenomics.com/u/sicklera/haydar-rna-harmonization/tasks/1e5d774c-caa2-4b2c-b833-6b38330053ca/

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] [Rerun of the sample with the bug](https://cavatica.sbgenomics.com/u/sicklera/haydar-rna-harmonization/tasks/3d737b8c-b90a-470c-8be6-01634e86bbf7/)
- [X] [Test run with an unaffected samples](https://cavatica.sbgenomics.com/u/sicklera/haydar-rna-harmonization/tasks/6a936c74-27cb-450a-95e7-160682ff2bda/#)

**Test Configuration**:
* Environment:
* Test files:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
- [X] I have committed any related changes to the PR
